### PR TITLE
Add Schemathesis to the users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Also used as test suite in the following projects:
  - [ardoq-swagger-addon](https://github.com/ardoq/ardoq-swagger-addon) - Ardoq OpenAPI addon
  - [swagvali](https://github.com/subeeshcbabu/swagvali/) - Module to build validators for OpenAPI Request parameters and Response objects
  - [swagger-search](https://github.com/IG-Group/swagger-search) - An application that collects and indexes swagger docs from your microservices architecture
+ - [Schemathesis](https://github.com/schemathesis/schemathesis) - Framework for property-based API testing
 
 
 Integration with 3rd-party services


### PR DESCRIPTION
I've been using `openapi-directory` in Schemathesis for quite a while and now I noticed this list :)